### PR TITLE
Add functionality to authenticate via client key + certificate

### DIFF
--- a/src/PsychicMqttClient.cpp
+++ b/src/PsychicMqttClient.cpp
@@ -177,6 +177,23 @@ PsychicMqttClient &PsychicMqttClient::setCredentials(const char *username, const
     return *this;
 }
 
+PsychicMqttClient &PsychicMqttClient::setClientCertificate(const char *clientCert, const char *clientKey,
+    size_t clientCertLen, size_t clientKeyLen)
+{
+#if ESP_IDF_VERSION_MAJOR == 5
+    _mqtt_cfg.credentials.authentication.certificate = clientCert;
+    _mqtt_cfg.credentials.authentication.key = clientKey;
+    _mqtt_cfg.credentials.authentication.certificate_len = clientCertLen;
+    _mqtt_cfg.credentials.authentication.key_len = clientKeyLen;
+#else
+    _mqtt_cfg.client_cert_pem = clientCert;
+    _mqtt_cfg.client_key_pem = clientKey;
+    _mqtt_cfg.client_cert_len = clientCertLen;
+    _mqtt_cfg.client_key_len = clientKeyLen;
+#endif
+    return *this;
+}
+
 PsychicMqttClient &PsychicMqttClient::setWill(const char *topic, uint8_t qos, bool retain, const char *payload, int length)
 {
 #if ESP_IDF_VERSION_MAJOR == 5

--- a/src/PsychicMqttClient.h
+++ b/src/PsychicMqttClient.h
@@ -173,6 +173,18 @@ public:
     PsychicMqttClient &setCredentials(const char *username, const char *password = nullptr);
 
     /**
+     * @brief Authenticate via mutual X.509 certificate.
+     *
+     * @param clientCert The X.509 certificate issued from the same CA as the server cert.
+     * @param clientKey The private key for the X.509 certificate.
+     * @param clientCertLen Optional length of the client certificate. If the certificate is not null-terminated.
+     * @param clientKeyLen Optional length of the client key. If the key is not null-terminated.
+     * @return A reference to the PsychicMqttClient instance.
+     */
+    PsychicMqttClient &setClientCertificate(const char *clientCert, const char *clientKey, size_t clientCertLen = 0,
+        size_t clientKeyLen = 0);
+
+    /**
      * @brief Sets the last will and testament for the MQTT connection.
      *
      * @param topic The topic for the last will and testament.


### PR DESCRIPTION
For secure MQTT implementations local hosters might use their own certificate authority to issue server and client certificates. See background [here](https://cedalo.com/blog/mqtt-authentication-and-authorization-on-mosquitto/). 

ESP-IDF supports this for MQTT, this brings this feature to the surface for this library. Usage, have your own hosted certificate authority for issuing a MQTT server and client certificate. For the MQTT client

1. `client.setCACert(<CA certificate>)`
2. `client.setClientCertificate(<clientCertificate>, <clientPrivateKey>)`

Note the server certificate the common name (CN) has to match the DNS name of the server to be able to connect. 

