### PR TITLE
strncpy truncates incoming binary

### DIFF
--- a/src/PsychicMqttClient.cpp
+++ b/src/PsychicMqttClient.cpp
@@ -506,12 +506,12 @@ void PsychicMqttClient::_onMessage(esp_mqtt_event_handle_t &event)
         ESP_LOGV(TAG, "MQTT_EVENT_DATA_SINGLE");
         // Copy the characters from data->data_ptr to c-string
         char payload[event->data_len + 1];
-        strncpy(payload, (char *)event->data, event->data_len);
+        memcpy(payload, (char *)event->data, event->data_len);
         payload[event->data_len] = '\0';
         ESP_LOGV(TAG, "Payload=%s", payload);
 
         char topic[event->topic_len + 1];
-        strncpy(topic, (char *)event->topic, event->topic_len);
+        memcpy(topic, (char *)event->topic, event->topic_len);
         topic[event->topic_len] = '\0';
         ESP_LOGV(TAG, "Topic=%s", topic);
 
@@ -531,11 +531,11 @@ void PsychicMqttClient::_onMessage(esp_mqtt_event_handle_t &event)
         // Allocate memory for the buffer
         _buffer = (char *)malloc(event->total_data_len + 1);
         // Copy the characters from even->data to _buffer
-        strncpy(_buffer, (char *)event->data, event->data_len);
+        memcpy(_buffer, (char *)event->data, event->data_len);
 
         // Store the topic for later use, as it is only sent with the first message
         _topic = (char *)malloc(event->topic_len + 1);
-        strncpy(_topic, (char *)event->topic, event->topic_len);
+        memcpy(_topic, (char *)event->topic, event->topic_len);
         _topic[event->topic_len] = '\0';
     }
 
@@ -544,7 +544,7 @@ void PsychicMqttClient::_onMessage(esp_mqtt_event_handle_t &event)
     {
         ESP_LOGV(TAG, "MQTT_EVENT_DATA_MULTIPART_LAST");
         // Copy the characters from even->data to _buffer
-        strncpy(_buffer + event->current_data_offset, (char *)event->data, event->data_len);
+        memcpy(_buffer + event->current_data_offset, (char *)event->data, event->data_len);
         _buffer[event->total_data_len] = '\0';
         ESP_LOGV(TAG, "Topic=%s", _topic);
         ESP_LOGV(TAG, "Payload=%s", _buffer);
@@ -568,7 +568,7 @@ void PsychicMqttClient::_onMessage(esp_mqtt_event_handle_t &event)
     else
     {
         // copy the characters from even->data to _buffer
-        strncpy(_buffer + event->current_data_offset, (char *)event->data, event->data_len);
+        memcpy(_buffer + event->current_data_offset, (char *)event->data, event->data_len);
         ESP_LOGV(TAG, "MQTT_EVENT_DATA_MULTIPART");
     }
 }


### PR DESCRIPTION
hi, this library is so cool

**tldr;** in this method `strncpy` truncates binary messages with null bytes, see [strncpy cppreference](https://en.cppreference.com/w/cpp/string/byte/strncpy.html). `memcpy` does fix this for me.

https://github.com/theelims/PsychicMqttClient/blob/39efbcf46ed23384ca445234a873fb4bfeadad64/src/PsychicMqttClient.cpp#L493

this quick fix is fine for me and perhaps is not the correct solution so please close this whenever. this is my first pr, perhaps you have some tips.

**more info** sending a large bitmap for an epaper works well but when receiving the this bitmap it is partial. a friend @julianstoerig  helped me and we tried `memcpy` instead of `strncpy`. this solves the issue for me. as far as we understand this `strncpy` copies null bytes for the rest of the length after it sees the first null byte. so it the bitmap in this was the same length total but had blank parts. `memcpy` does not do this.